### PR TITLE
Upgrade AI tutor CLI and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# test
+# AI Tutor App
+
+This repository contains a simple command line AI tutor application. The tutor asks a series of questions from different categories and checks your answers.
+
+## Requirements
+
+The script uses only the Python standard library and requires Python 3.7+.
+
+## Usage
+
+Run the tutor from the repository root:
+
+```bash
+python3 ai_tutor.py --list   # show categories
+python3 ai_tutor.py math     # run math questions
+```
+
+If no category is provided, the app will prompt you to choose one interactively.

--- a/ai_tutor.py
+++ b/ai_tutor.py
@@ -1,0 +1,125 @@
+"""Command line AI Tutor application."""
+
+from __future__ import annotations
+
+import argparse
+import random
+from typing import Callable, Iterable
+
+# Dataset of questions by category
+QUESTIONS: dict[str, list[dict[str, str]]] = {
+    "math": [
+        {
+            "question": "What is 2 + 2?",
+            "answer": "4",
+            "explanation": "Adding two plus two equals four."
+        },
+        {
+            "question": "What is the square root of 16?",
+            "answer": "4",
+            "explanation": "Four times four equals sixteen."
+        },
+        {
+            "question": "Solve for x: 2x = 10",
+            "answer": "5",
+            "explanation": "Divide both sides by 2 to get x = 5."
+        },
+    ],
+    "science": [
+        {
+            "question": "What gas do plants breathe in that humans and animals breathe out?",
+            "answer": "carbon dioxide",
+            "explanation": "Plants take in carbon dioxide for photosynthesis."
+        },
+        {
+            "question": "How many planets are in our solar system?",
+            "answer": "8",
+            "explanation": "There are eight recognized planets orbiting the Sun."
+        },
+    ],
+    "history": [
+        {
+            "question": "Who was the first president of the United States?",
+            "answer": "George Washington",
+            "explanation": "George Washington served as president from 1789 to 1797."
+        },
+        {
+            "question": "In what year did World War II end?",
+            "answer": "1945",
+            "explanation": "The war ended in 1945 with the surrender of Japan."
+        },
+    ],
+}
+
+
+class Tutor:
+    """Tutor asks questions from a category and tracks the user's score."""
+
+    def __init__(self, category: str) -> None:
+        """Initialize the Tutor with a question category."""
+        if category not in QUESTIONS:
+            raise ValueError(f"Unknown category: {category}")
+        self.questions = list(QUESTIONS[category])
+        random.shuffle(self.questions)
+        self.correct = 0
+        self.total = len(self.questions)
+
+    def ask(
+        self,
+        input_fn: Callable[[str], str] = input,
+        output_fn: Callable[[str], None] = print,
+    ) -> None:
+        """Iteratively ask questions using provided input/output functions."""
+        for q in list(self.questions):
+            output_fn("\n" + q["question"])
+            user_answer = input_fn("Your answer: ").strip().lower()
+            if user_answer == q["answer"].lower():
+                output_fn("Correct!")
+                self.correct += 1
+            else:
+                output_fn(f"Incorrect. The correct answer is: {q['answer']}")
+                output_fn("Explanation: " + q["explanation"])
+            
+        print(f"\nYour score: {self.correct}/{self.total}")
+
+
+def parse_args(args: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="AI Tutor")
+    parser.add_argument(
+        "category",
+        nargs="?",
+        help="question category",
+        choices=list(QUESTIONS.keys()),
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="list available categories and exit",
+    )
+    return parser.parse_args(args)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.list:
+        print("Available categories:")
+        for cat in QUESTIONS:
+            print(f"- {cat}")
+        return
+
+    category = args.category
+    if category is None:
+        category = input(f"Choose a category {list(QUESTIONS.keys())}: ").strip().lower()
+
+    try:
+        tutor = Tutor(category)
+    except ValueError as e:
+        print(e)
+        return
+    tutor.ask()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_tutor.py
+++ b/tests/test_tutor.py
@@ -1,0 +1,19 @@
+import builtins
+import types
+import pytest
+
+import ai_tutor
+
+
+def test_unknown_category():
+    with pytest.raises(ValueError):
+        ai_tutor.Tutor('unknown')
+
+
+def test_all_correct(monkeypatch):
+    tutor = ai_tutor.Tutor('math')
+    answers = [q['answer'] for q in tutor.questions]
+    inputs = iter(answers)
+    monkeypatch.setattr(builtins, 'input', lambda _: next(inputs))
+    tutor.ask()
+    assert tutor.correct == tutor.total


### PR DESCRIPTION
## Summary
- refactor `ai_tutor.py` with argparse-based CLI and docstrings
- allow dependency injection for testability
- add simple `pytest` tests for the tutor logic
- update README with new usage instructions

## Testing
- `python3 ai_tutor.py --list`
- `python3 ai_tutor.py math <<'EOF'
4
4
5
EOF`
- `pytest -q` *(fails: command not found)*
- `python3 -m pytest -q` *(fails: No module named pytest)*