### PR TITLE
Improve AI tutor CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# test
+# AI Tutor App
+
+This repository contains a simple command line AI tutor application. The tutor asks a series of questions from different categories and checks your answers.
+
+## Requirements
+
+The script uses only the Python standard library and requires Python 3.7+.
+
+## Usage
+
+Run the tutor from the repository root.
+
+List available categories:
+
+```bash
+python3 ai_tutor.py --list
+```
+
+Start a session for a specific category (e.g. math):
+
+```bash
+python3 ai_tutor.py math
+```

--- a/ai_tutor.py
+++ b/ai_tutor.py
@@ -1,0 +1,119 @@
+"""Command-line AI tutor application."""
+
+from __future__ import annotations
+
+import argparse
+import random
+from typing import Dict, List
+
+# Dataset of questions by category
+QUESTIONS = {
+    "math": [
+        {
+            "question": "What is 2 + 2?",
+            "answer": "4",
+            "explanation": "Adding two plus two equals four."
+        },
+        {
+            "question": "What is the square root of 16?",
+            "answer": "4",
+            "explanation": "Four times four equals sixteen."
+        },
+        {
+            "question": "Solve for x: 2x = 10",
+            "answer": "5",
+            "explanation": "Divide both sides by 2 to get x = 5."
+        },
+    ],
+    "science": [
+        {
+            "question": "What gas do plants breathe in that humans and animals breathe out?",
+            "answer": "carbon dioxide",
+            "explanation": "Plants take in carbon dioxide for photosynthesis."
+        },
+        {
+            "question": "How many planets are in our solar system?",
+            "answer": "8",
+            "explanation": "There are eight recognized planets orbiting the Sun."
+        },
+    ],
+    "history": [
+        {
+            "question": "Who was the first president of the United States?",
+            "answer": "George Washington",
+            "explanation": "George Washington served as president from 1789 to 1797."
+        },
+        {
+            "question": "In what year did World War II end?",
+            "answer": "1945",
+            "explanation": "The war ended in 1945 with the surrender of Japan."
+        },
+    ],
+}
+
+
+class Tutor:
+    """Simple tutor that asks questions and tracks correct answers."""
+
+    def __init__(self, category: str, questions: Dict[str, List[dict]] = QUESTIONS):
+        if category not in questions:
+            raise ValueError(f"Unknown category: {category}")
+        # shuffle questions for randomness
+        self.questions = list(questions[category])
+        random.shuffle(self.questions)
+        self.correct = 0
+        self.total = len(self.questions)
+
+    def ask(self, input_fn=input, print_fn=print) -> int:
+        """Ask all questions using provided input and print functions."""
+        for q in self.questions:
+            print_fn("\n" + q["question"])
+            user_answer = input_fn("Your answer: ").strip().lower()
+            if user_answer == q["answer"].lower():
+                print_fn("Correct!")
+                self.correct += 1
+            else:
+                print_fn(f"Incorrect. The correct answer is: {q['answer']}")
+                print_fn("Explanation:", q["explanation"])
+
+        print_fn(f"\nYour score: {self.correct}/{self.total}")
+        return self.correct
+
+
+def list_categories() -> List[str]:
+    """Return the list of available categories."""
+    return list(QUESTIONS.keys())
+
+
+def main(argv: List[str] | None = None) -> int:
+    """Entry point for the CLI."""
+    parser = argparse.ArgumentParser(description="Simple AI Tutor")
+    parser.add_argument("category", nargs="?", help="Question category")
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available categories and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list:
+        print("Available categories:", ", ".join(list_categories()))
+        return 0
+
+    if not args.category:
+        parser.print_help()
+        return 1
+
+    try:
+        tutor = Tutor(args.category)
+    except ValueError as exc:
+        print(exc)
+        return 1
+
+    tutor.ask()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/test_ai_tutor.py
+++ b/tests/test_ai_tutor.py
@@ -1,0 +1,20 @@
+import builtins
+from unittest import mock
+import pytest
+
+from ai_tutor import Tutor
+
+
+def test_invalid_category():
+    with pytest.raises(ValueError):
+        Tutor("invalid")
+
+
+def test_scoring_all_correct():
+    answers = ["4", "4", "5"]
+    with mock.patch.object(builtins, "input", side_effect=answers):
+        tutor = Tutor("math")
+        with mock.patch.object(builtins, "print"):
+            tutor.ask()
+    assert tutor.correct == len(answers)
+


### PR DESCRIPTION
## Summary
- modernize `ai_tutor.py` to use `argparse` and add docstrings
- add ability to list available categories
- provide unit tests for scoring and category validation
- update README usage instructions

## Testing
- `pytest -q` *(fails: command not found)*
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `python3 ai_tutor.py --list`
- `python3 ai_tutor.py math <<'EOF'
4
4
5
EOF`